### PR TITLE
Image processing support for zotero notes

### DIFF
--- a/src/bbt/exportNotes.ts
+++ b/src/bbt/exportNotes.ts
@@ -18,11 +18,12 @@ export function processZoteroAnnotationNotes(noteStr: string) {
 
       const attachmentKey = json.attachmentURI.split('/').pop();
 
-      annot.createSpan({ text: ' ' });
-      annot.createEl('a', {
+      const isImage = annot instanceof HTMLImageElement
+      annot.insertAdjacentElement(isImage ? 'afterend' : 'afterbegin', createEl('a', {
         text: 'Go to annotation',
         href: `zotero://open-pdf/library/items/${attachmentKey}?page=${json.pageLabel}&annotation=${json.annotationKey}`,
-      });
+      }));
+      annot.insertAdjacentElement(isImage ? 'afterend' : 'afterbegin', createSpan({ text: ' ' }));
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
As I played around with the plugin I noticed that the "Go to annotation" link does not exist when processing image annotations.
The link which gets created is added as a child element of the annotation. As the htmlToMarkdown method from the Turndown Service ignores child elements of image elements that means the link is not part of the final note. Thus the "Go to annotation" needs to be added as a sibling instead of a child.