### PR TITLE
Workaround errors when annotation is of type ink

### DIFF
--- a/src/bbt/export.ts
+++ b/src/bbt/export.ts
@@ -85,7 +85,14 @@ function convertNativeAnnotation(
   imageRelativePath: string,
   copy: boolean = false
 ) {
-  const rect = annotation.annotationPosition.rects[0];
+  var rect;
+  // Currently ink annotation aren't properly imported. The location is
+  // for now set to a dummy value.
+  if(annotation.annotationType == "ink") {
+    rect = ["0", "0"];
+  } else {
+    rect = annotation.annotationPosition.rects[0];
+  }
 
   const annot: Record<string, any> = {
     date: moment(annotation.dateModified),

--- a/src/bbt/export.ts
+++ b/src/bbt/export.ts
@@ -85,11 +85,11 @@ function convertNativeAnnotation(
   imageRelativePath: string,
   copy: boolean = false
 ) {
-  var rect;
+  let rect = [];
   // Currently ink annotation aren't properly imported. The location is
   // for now set to a dummy value.
-  if(annotation.annotationType == "ink") {
-    rect = ["0", "0"];
+  if (annotation.annotationType == 'ink') {
+    rect = ['0', '0'];
   } else {
     rect = annotation.annotationPosition.rects[0];
   }


### PR DESCRIPTION
The import fails right now when the PDF has an annotation type ink. See https://github.com/mgmeyers/obsidian-zotero-integration/issues/110

While this doesn't fix the issue of not important "ink" annotations, it prevents the plugin from failing on import. It also provides meta data that there is some annotation of type "ink".