### PR TITLE
Automatically open notes after import

### DIFF
--- a/src/DataExplorerView.tsx
+++ b/src/DataExplorerView.tsx
@@ -90,11 +90,6 @@ function TemplatePreview({
       }
     };
     
-    const onImport = (file: TFile) => {
-      if (!file) return;
-    };
-
-
     const onSettingsUpdate = () => {
       setForceRef(Date.now());
     };

--- a/src/DataExplorerView.tsx
+++ b/src/DataExplorerView.tsx
@@ -89,6 +89,11 @@ function TemplatePreview({
         setForceRef(Date.now());
       }
     };
+    
+    const onImport = (file: TFile) => {
+      if (!file) return;
+    };
+
 
     const onSettingsUpdate = () => {
       setForceRef(Date.now());

--- a/src/bbt/export.ts
+++ b/src/bbt/export.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { Notice, TFile, htmlToMarkdown, moment, normalizePath } from 'obsidian';
+import { Notice, TFile, htmlToMarkdown, moment, normalizePath, Events } from 'obsidian';
 
 import { doesEXEExist, getVaultRoot } from '../helpers';
 import {
@@ -8,6 +8,7 @@ import {
   ExportToMarkdownParams,
   RenderCiteTemplateParams,
   ZoteroConnectorSettings,
+  MarkdownFileKeyAndPath,
 } from '../types';
 import { applyBasicTemplates } from './basicTemplates/applyBasicTemplates';
 import { getCiteKeys } from './cayw';
@@ -416,7 +417,7 @@ export function getATemplatePath({ exportFormat }: ExportToMarkdownParams) {
   );
 }
 
-export async function exportToMarkdown(params: ExportToMarkdownParams) {
+export async function exportToMarkdown(params: ExportToMarkdownParams, importEvents?: Events) {
   const importDate = moment();
   const { database, exportFormat, settings } = params;
   const sourcePath = getATemplatePath(params);
@@ -433,15 +434,27 @@ export async function exportToMarkdown(params: ExportToMarkdownParams) {
     return false;
   }
 
+  // Variable to store the paths of the markdown files that will be created on import.
+  // This is an array of an interface defined by a citekey and a path.
+  // We first store the citekey in the order of the retrieved item data to save the order input by the user.
+  // Further down below, when the Markdown file path has been sanitized, we associate the path to the key.
+  let createdOrUpdatedMarkdownFiles: MarkdownFileKeyAndPath[] = [];
+
   for (let i = 0, len = itemData.length; i < len; i++) {
     await processItem(itemData[i], importDate, database, exportFormat.cslStyle);
+    // Store the order of the files as they were input
+    createdOrUpdatedMarkdownFiles.push({key: itemData[i].citekey});
   }
 
   const vaultRoot = getVaultRoot();
 
+  // Store the path of markdown files that will be created/updated 
+  // on import to open them later
+
   for (let i = 0, len = itemData.length; i < len; i++) {
     const attachments = itemData[i].attachments as any[];
     const hasPDF = attachments.some((a) => a.path?.endsWith('.pdf'));
+    const itemIndex = createdOrUpdatedMarkdownFiles.findIndex((file => file.key == itemData[i].citekey));
 
     // Handle the case of an item with no PDF attachments
     if (!hasPDF) {
@@ -487,6 +500,8 @@ export async function exportToMarkdown(params: ExportToMarkdownParams) {
         app.vault.create(markdownPath, rendered);
       }
 
+      createdOrUpdatedMarkdownFiles[itemIndex].path = markdownPath;
+      
       continue;
     }
 
@@ -661,7 +676,15 @@ export async function exportToMarkdown(params: ExportToMarkdownParams) {
         await mkMDDir(markdownPath);
         app.vault.create(markdownPath, rendered);
       }
+      createdOrUpdatedMarkdownFiles[itemIndex].path = markdownPath;
     }
+  }
+
+  // If importEvents has been provided, fire an event to state that the import is complete 
+  // and send the created or updated markdown files in order of input as an array of paths
+  if(importEvents instanceof Events) {
+    const createdOrUpdatedMarkdownFilesPaths = createdOrUpdatedMarkdownFiles.map(({key, path}) => (path));
+    importEvents.trigger('import-complete', createdOrUpdatedMarkdownFilesPaths);
   }
 
   return true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,7 +90,7 @@ export default class ZoteroConnector extends Plugin {
             }
         }
       }
-    });
+    }});
 
     this.registerEvent(
       this.app.vault.on('modify', (file) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,6 @@ import { currentVersion, downloadAndExtract } from './settings/AssetDownloader';
 import { ZoteroConnectorSettingsTab } from './settings/settings';
 import { CitationFormat, ExportFormat, ZoteroConnectorSettings } from './types';
 import { CiteSuggest } from './citeSuggest/citeSuggest';
-import { off } from 'process';
 
 const commandPrefix = 'obsidian-zotero-desktop-connector:';
 const citationCommandIDPrefix = 'zdc-';

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -41,6 +41,8 @@ function SettingsComponent({
     settings.exportFormats
   );
 
+  const [openNoteAfterImportState, setOpenNoteAfterImport] = React.useState(!!settings.openNoteAfterImport);
+
   const [ocrState, setOCRState] = React.useState(settings.pdfExportImageOCR);
   const [citeSuggestState, setCiteSuggestState] = React.useState(
     !!settings.shouldShowCiteSuggest
@@ -132,6 +134,34 @@ function SettingsComponent({
           placeholder="Example: folder 1/folder 2"
           defaultValue={settings.noteImportFolder}
         />
+      </SettingItem>
+      <SettingItem
+        name="Open the created or updated note(s) after import"
+        description="The crated or updated markdown files resulting from the import will be automatically opened."
+      >
+        <div
+          onClick={() => {
+            setOpenNoteAfterImport((state) => {
+              updateSetting('openNoteAfterImport', !state);
+              return !state;
+            });
+          }}
+          className={`checkbox-container${openNoteAfterImportState ? ' is-enabled' : ''}`}
+        />
+      </SettingItem>
+      <SettingItem 
+        name="Which notes to open after import" 
+        description="Open either the first note imported, the last note imported, or all notes in new tabs.">
+        <select
+          className="dropdown"
+          defaultValue={settings.whichNotesToOpenAfterImport}
+          disabled={!settings.openNoteAfterImport}
+          onChange={(e) => updateSetting('whichNotesToOpenAfterImport', e.target.value)}
+        >
+          <option value="first-imported-note">First imported note</option>
+          <option value="last-imported-note">Last imported note</option>
+          <option value="all-imported-notes">All imported notes</option>
+        </select>
       </SettingItem>
       <SettingItem
         name="Enable Cite Key Autocomplete"

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface CitationFormat {
 
 export type Database = 'Zotero' | 'Juris-M';
 
+export type NotesToOpenAfterImport = 'first-imported-note' | 'last-imported-note' | 'all-imported-notes';
+
 export interface CalloutDef {
   type: string;
   prefix: string;
@@ -64,6 +66,8 @@ export interface RenderCiteTemplateParams {
 export interface ZoteroConnectorSettings {
   database: Database;
   noteImportFolder: string;
+  openNoteAfterImport: boolean;
+  whichNotesToOpenAfterImport: NotesToOpenAfterImport;
   citeFormats: CitationFormat[];
   exportFormats: ExportFormat[];
   pdfExportImageDPI?: number;
@@ -77,4 +81,9 @@ export interface ZoteroConnectorSettings {
   settingsVersion?: number;
   shouldShowCiteSuggest?: boolean;
   shouldConcat?: boolean;
+}
+
+export interface MarkdownFileKeyAndPath {
+  key: string;
+  path?: string;
 }


### PR DESCRIPTION
## What?
I have added a setting to automatically open the created/updated Markdown files after the import process from Zotero. The user can decide either to open the note(s) resulting from the first imported file, the last imported file or all imported files.
## Why?
This functionality is lacking for the moment, even though you would expect to be able to readily open the newly created note(s) after import. Issue #94 suggests this features. 
## How?
The implementation relies on the creation of a custom event, "import-completed", that is fired once the function `exportToMarkdown` has run. It triggers with a list of path that includes all the notes created or updated during the import process. To do so, the keys of all items are first stored in an array when processing items at the beginning of the function, to store the order in which they were provided by the user. Then, the keys are completed with the associated file path when the sanitised file path has been generated. 

When the event is triggered, it is detected within the `main.ts` file with a custom hook. The rationale behind the use of a custom event is to avoid putting all the logic related to opening files depending on users preferences in `exportToMarkdown`, given that these operations are outside of the scope of this function. The hook receives the list of paths, and depending on user preferences, store the path(s) of the first file imported, the last file imported, or all files imported. Then, the stored paths are sent to a dedicated function to open the corresponding files in new leaves. This last operation is carried out after a one-second delay, as a band-aid fix of some cases where the vault does not seem to be refreshed quickly enough for the files to be detected as existing when trying to open them. Perhaps there is a better way to do this!