### PR TITLE
Import from Zotero even if there is a type 3 error in one of the annotations

### DIFF
--- a/src/bbt/extractAnnotations.ts
+++ b/src/bbt/extractAnnotations.ts
@@ -90,6 +90,13 @@ export async function extractAnnotations(input: string, params: ExtractParams) {
       );
       return '[]';
     }
+    
+    else if (e.message.toLowerCase().includes('type3')) {
+      new Notice(
+        `Error processing annotations: ${e.message}`, 10000
+      );
+      return '[]';
+    }
 
     console.error(e);
     new Notice(`Error processing PDF: ${e.message}`, 10000);


### PR DESCRIPTION
Hi!

It's quite common in my workflow to encounter the following error while importing articles from Zotero: 
![image](https://user-images.githubusercontent.com/17215876/201444174-3f849ffd-8043-41cc-a757-b91a912cf3a4.png)

I know the error is caused from the external tool used to extract the annotations, but I would prefer that the rest of the annotations and the rest of the article's information would still be imported.

This modification still shows an error to the user, to inform that some annotation couldn't be imported, but the rest will be imported.

Let me know if you would prefer changing the notification to the user.

Best regards,
Marc B.