### PR TITLE
Handle arg strings that require quotes

### DIFF
--- a/src/bbt/extractAnnotations.ts
+++ b/src/bbt/extractAnnotations.ts
@@ -54,7 +54,11 @@ export async function extractAnnotations(input: string, params: ExtractParams) {
       }
     } else {
       args.push(key);
-      args.push(val.toString());
+      if (val.toString().contains(" ") || (val.toString().startsWith("-") && typeof val === 'string')) {
+        args.push(`\"${val.toString()}\"`);
+      } else {
+        args.push(val.toString());
+      }
     }
   });
 


### PR DESCRIPTION
It is possible for a few of the args to be formatted in a manner that pdf2annots fails to parse (strings starting with a `-` or containing spaces). This change resolves that issue.

I ran into this issue with a few of my Zotero entries when I set up my integration today, I do not know if my Zotero library was in a corrupted or unexpected state, but regardless this change allowed me to import the entries properly.

This plugin is great, thank you! I hope this helps.