### PR TITLE
Fix blue and purple color categories

### DIFF
--- a/src/bbt/helpers.ts
+++ b/src/bbt/helpers.ts
@@ -114,10 +114,10 @@ export function getColorCategory(hex: string) {
   if (h < 190) {
     return 'Cyan';
   }
-  if (h < 263) {
+  if (h < 255) {
     return 'Blue';
   }
-  if (h < 255) {
+  if (h < 280) {
     return 'Purple';
   }
   if (h < 335) {

--- a/src/bbt/helpers.ts
+++ b/src/bbt/helpers.ts
@@ -117,7 +117,7 @@ export function getColorCategory(hex: string) {
   if (h < 263) {
     return 'Blue';
   }
-  if (h < 280) {
+  if (h < 255) {
     return 'Purple';
   }
   if (h < 335) {


### PR DESCRIPTION
This correct a mix-up between blue and purple color categories in regard to the color definition used by zotero.

Zotero defines these colors (<https://github.com/zotero/pdf-reader/blob/master/src/lib/colors.js>):

Name | hex | H | S | V
--- | ---: | ---: | ---: | ---:
Blue |  #2EA8E5 | 200° | 80° | 90°
Purple |  #A28AE5 |  256° | 40° | 90°

So we can stop the blue color at 255!