### PR TITLE
Recognition of Purple color from Zotero

### DIFF
--- a/src/bbt/helpers.ts
+++ b/src/bbt/helpers.ts
@@ -111,7 +111,7 @@ export function getColorCategory(hex: string) {
   if (h < 190) {
     return 'Cyan';
   }
-  if (h < 263) {
+  if (h < 220) {
     return 'Blue';
   }
   if (h < 280) {


### PR DESCRIPTION
In order to be able to recognize the Purple highlighting color from Zotero, Update helpers.ts must be updated to lower the limit for the color range that is considered as "Blue" from 263 to 220 (Or similar, but 220 works fine).