### PR TITLE
Add option to allow importing item date as ISO 8601 string with reduced accuracy of dates

### DIFF
--- a/src/bbt/jsonRPC.ts
+++ b/src/bbt/jsonRPC.ts
@@ -453,7 +453,8 @@ export async function getItemJSONFromRelations(
 
 export async function getIssueDateFromCiteKey(
   citeKey: CiteKey,
-  database: DatabaseWithPort
+  database: DatabaseWithPort,
+  dateAsString: boolean
 ) {
   let res: string;
 
@@ -509,12 +510,16 @@ export async function getIssueDateFromCiteKey(
 
         if (!dateParts.length) return null;
 
-        const date = moment(
-          `${dateParts[0]}-${dateParts[1] ? padNumber(dateParts[1]) : '01'}-${
-            dateParts[2] ? padNumber(dateParts[2]) : '01'
-          }`,
-          'YYYY-MM-DD'
-        );
+        const date = dateAsString
+          ? `${dateParts[0]}${
+              dateParts[1] ? `-${padNumber(dateParts[1])}` : ''
+            }${dateParts[2] ? `-${padNumber(dateParts[2])}` : ''}`
+          : moment(
+              `${dateParts[0]}-${
+                dateParts[1] ? padNumber(dateParts[1]) : '01'
+              }-${dateParts[2] ? padNumber(dateParts[2]) : '01'}`,
+              'YYYY-MM-DD'
+            );
 
         return date;
       })

--- a/src/settings/ExportFormatSettings.tsx
+++ b/src/settings/ExportFormatSettings.tsx
@@ -4,6 +4,7 @@ import AsyncSelect from 'react-select/async';
 
 import { ExportFormat } from '../types';
 import { Icon } from './Icon';
+import { SettingItem } from './SettingItem';
 import { cslListRaw } from './cslList';
 import {
   NoFileOptionMessage,
@@ -78,6 +79,16 @@ export function ExportFormatSettings({
       updateFormat(index, {
         ...format,
         templatePath: e?.value,
+      });
+    },
+    [updateFormat, index, format]
+  );
+
+  const onChangeDateAsString = React.useCallback(
+    (e: SingleValue<{ value: boolean; label: string }>) => {
+      updateFormat(index, {
+        ...format,
+        dateAsString: e?.value,
       });
     },
     [updateFormat, index, format]
@@ -320,6 +331,34 @@ export function ExportFormatSettings({
           >
             Zotero: Citation Styles
           </a>
+        </div>
+      </div>
+
+      <div className="zt-format__form">
+        <div className="zt-format__label">
+          Import "date" field as ISO 8601 string
+        </div>
+        <div className="zt-format__input-wrapper">
+          <SettingItem
+            description={`Imports the date field as an ISO 8601 string instead of a UNIX timestamp. Allows for reduced accuracy of dates, e.g. "2021-04".`}
+          >
+            <div
+              onClick={() =>
+                onChangeDateAsString({
+                  value: !format.dateAsString,
+                  label: (!format.dateAsString).toString(),
+                })
+              }
+              className={`checkbox-container${
+                format.dateAsString ? ' is-enabled' : ''
+              }`}
+            />
+          </SettingItem>
+        </div>
+        <div className="zt-format__input-note">
+          Note, if you turn this on: Don't use{' '}
+          <pre>{`{{date | format(...)}}`}</pre> in your template or it will
+          generate an error message into your output.
         </div>
       </div>
     </div>

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -96,6 +96,7 @@ function SettingsComponent({
         outputPathTemplate: '{{citekey}}.md',
         imageOutputPathTemplate: '{{citekey}}/',
         imageBaseNameTemplate: 'image',
+        dateAsString: false,
       })
     );
   }, [addExportFormat, citeFormatState]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface ExportFormat {
 
   templatePath?: string;
   cslStyle?: string;
+  dateAsString: boolean;
 
   // Deprecated
   headerTemplatePath?: string;


### PR DESCRIPTION
Hey 👋
This PR adds a toggle to any import format inside the plugin settings to import the `date` field as an ISO 8601 string instead of a UNIX timestamp.

The default will still be the UNIX timestamp, so this only affects anything if you explicitly turn the toggle on.

## Why is this necessary?
This option allows for importing dates with *reduced accuracy*.
- E.g.: "2024-01" can be imported as "2024-01" if no day is specified.

This is currently not possible, because any date will arrive as a UNIX timestamp in Obsidian.
- E.g.: "2024-01" arrives as "1/1/2024 12:00:00 AM" in the Data Explorer.

See: https://github.com/mgmeyers/obsidian-zotero-integration/issues/417 for more context :)