### PR TITLE
fix(settings): update the `Enable Annotation Concatenation` description

### DIFF
--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -210,7 +210,7 @@ function SettingsComponent({
       </SettingItem>
       <SettingItem
         name="Enable Annotation Concatenation"
-        description="Annotations extracted from PDFs that begin with '+' will be appended to the previous annotation. Note: Annotation ordering is not always consistent and you may not always acheive the desire concatenation result"
+        description="Annotations extracted from PDFs that begin with '+' will be appended to the previous annotation. Note: Annotation ordering is not always consistent and you may not always achieve the desired concatenation result"
       >
         <div
           onClick={() => {


### PR DESCRIPTION
Fix a typo (`acheive` -> `achieve`) and a grammar issue (`desire` -> `desired`)