### PR TITLE
Add confirmation modal for overwriting existing literature notes

### DIFF
--- a/src/bbt/ConfirmationModal.ts
+++ b/src/bbt/ConfirmationModal.ts
@@ -1,0 +1,59 @@
+import { App, Modal } from 'obsidian';
+
+export class ConfirmationModal extends Modal {
+  private resolvePromise: (value: boolean) => void;
+  private promise: Promise<boolean>;
+
+  constructor(app: App, private title: string, private message: string) {
+    super(app);
+    this.promise = new Promise((resolve) => {
+      this.resolvePromise = resolve;
+    });
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    // Create modal content
+    const container = contentEl.createDiv('confirmation-modal');
+    
+    // Title
+    const titleEl = container.createEl('h2', { text: this.title });
+    titleEl.addClass('confirmation-modal-title');
+    
+    // Message
+    const messageEl = container.createEl('p', { text: this.message });
+    messageEl.addClass('confirmation-modal-message');
+    
+    // Buttons container
+    const buttonContainer = container.createDiv('confirmation-modal-buttons');
+    
+    // Cancel button
+    const cancelButton = buttonContainer.createEl('button', { text: 'Cancel' });
+    cancelButton.addClass('mod-warning');
+    cancelButton.addEventListener('click', () => {
+      this.resolvePromise(false);
+      this.close();
+    });
+    
+    // Confirm button
+    const confirmButton = buttonContainer.createEl('button', { text: 'Overwrite' });
+    confirmButton.addClass('mod-cta');
+    confirmButton.addEventListener('click', () => {
+      this.resolvePromise(true);
+      this.close();
+    });
+    
+    // Focus on cancel button by default
+    cancelButton.focus();
+  }
+
+  onClose() {
+    this.contentEl.empty();
+  }
+
+  async waitForResult(): Promise<boolean> {
+    return this.promise;
+  }
+} 

--- a/styles.css
+++ b/styles.css
@@ -236,3 +236,41 @@
     box-shadow: 0 1em 0 0;
   }
 }
+
+/* Confirmation Modal Styles */
+.confirmation-modal {
+  padding: 1rem;
+  text-align: center;
+}
+
+.confirmation-modal-title {
+  margin: 0 0 1rem 0;
+  color: var(--text-normal);
+  font-size: 1.2em;
+  font-weight: 600;
+}
+
+.confirmation-modal-message {
+  margin: 0 0 1.5rem 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.confirmation-modal-buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.confirmation-modal-buttons button {
+  min-width: 80px;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-s);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.confirmation-modal-buttons button:hover {
+  transform: translateY(-1px);
+}


### PR DESCRIPTION
- Implemented a new ConfirmationModal class to prompt users before overwriting existing files.
- Styled the modal with appropriate CSS for better user experience.
- Integrated the modal into the exportToMarkdown function to ensure user confirmation before file modification.