### PR TITLE
Handle empty annotation rects in non-pdf sources.

### DIFF
--- a/src/bbt/export.ts
+++ b/src/bbt/export.ts
@@ -140,7 +140,7 @@ function convertNativeAnnotation(
       annot.page = annotation.annotationPosition.pageIndex + 1
     }
 
-    if (annotation.annotationPosition.rects) {
+    if (annotation.annotationPosition.rects && annotation.annotationPosition.rects.length > 0) {
       annot.x = annotation.annotationPosition.rects[0][0];
       annot.y = annotation.annotationPosition.rects[0][1];
     }


### PR DESCRIPTION
Handle the case where `annotationPosition.rects` is an empty array.

When capturing some web pages via the Zotero Connector and then adding annotations in Zotero, the `rects` property is an empty array. This results in the content failing to import and the following error in the developer console:

```
plugin:obsidian-zotero-desktop-connector:123 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '0')
    at Jx (plugin:obsidian-zotero-desktop-connector:123:3272)
    at eval (plugin:obsidian-zotero-desktop-connector:126:4952)
    at Array.forEach (<anonymous>)
    at Kx (plugin:obsidian-zotero-desktop-connector:126:4933) 
```

which corresponds to this access `annotation.annotationPosition.rects[0][0];`

## Example data from my sqlite DB
```json
{"rects":[],"type":"CssSelector","value":"p:nth-child(63)"}
{"rects":[],"type":"CssSelector","value":"p:nth-child(4)","refinedBy":{"end":414,"start":0,"type":"TextPositionSelector"}}
{"rects":[],"type":"CssSelector","refinedBy":{"type":"TextPositionSelector","end":8346,"start":7224},"value":"#post-38661 > div:last-child"}
```

## Environment:

- BetterBibTex: 7.0.70
- Obsidian: 1.10.6
- Obsidian Zotero Integration: 3.2.1
- Zotero: 7.0.30
- Zotero Connector: 5.0.193