### PR TITLE
Feature: Add embedded note images import support

### DIFF
--- a/src/bbt/export.ts
+++ b/src/bbt/export.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, existsSync, mkdirSync } from 'fs';
-import { Notice, TFile, htmlToMarkdown, moment, normalizePath } from 'obsidian';
+import { Notice, TFile, moment, normalizePath } from 'obsidian';
 import path from 'path';
 
 import { doesEXEExist, getVaultRoot } from '../helpers';
@@ -11,7 +11,7 @@ import {
 } from '../types';
 import { applyBasicTemplates } from './basicTemplates/applyBasicTemplates';
 import { CiteKey, getCiteKeyFromAny, getCiteKeys } from './cayw';
-import { processZoteroAnnotationNotes } from './exportNotes';
+import { getNotesMarkdownByCiteKey } from './exportNotes';
 import { extractAnnotations } from './extractAnnotations';
 import {
   getColorCategory,
@@ -44,11 +44,6 @@ async function processNote(
   database: DatabaseWithPort,
   cslStyle?: string
 ) {
-  if (note.note) {
-    note.note = htmlToMarkdown(
-      await processZoteroAnnotationNotes(citeKey.key, note.note, {})
-    );
-  }
   if (note.dateAdded) {
     note.dateAdded = moment(note.dateAdded);
   }
@@ -445,10 +440,10 @@ export async function renderTemplates(
   try {
     header = headerTemplate
       ? await renderTemplate(
-          params.exportFormat.headerTemplatePath,
-          headerTemplate,
-          templateData
-        )
+        params.exportFormat.headerTemplatePath,
+        headerTemplate,
+        templateData
+      )
       : '';
   } catch (e) {
     if (shouldThrow) {
@@ -470,10 +465,10 @@ export async function renderTemplates(
   try {
     annotations = annotationTemplate
       ? await renderTemplate(
-          params.exportFormat.annotationTemplatePath,
-          annotationTemplate,
-          templateData
-        )
+        params.exportFormat.annotationTemplatePath,
+        annotationTemplate,
+        templateData
+      )
       : '';
   } catch (e) {
     if (shouldThrow) {
@@ -495,10 +490,10 @@ export async function renderTemplates(
   try {
     footer = footerTemplate
       ? await renderTemplate(
-          params.exportFormat.footerTemplatePath,
-          footerTemplate,
-          templateData
-        )
+        params.exportFormat.footerTemplatePath,
+        footerTemplate,
+        templateData
+      )
       : '';
   } catch (e) {
     if (shouldThrow) {
@@ -703,31 +698,46 @@ export async function exportToMarkdown(
 
       const imageRelativePath = exportFormat.imageOutputPathTemplate
         ? normalizePath(
-            sanitizeFilePath(
-              removeStartingSlash(
-                await renderTemplate(
-                  sourcePath,
-                  exportFormat.imageOutputPathTemplate,
-                  pathTemplateData
-                )
+          sanitizeFilePath(
+            removeStartingSlash(
+              await renderTemplate(
+                sourcePath,
+                exportFormat.imageOutputPathTemplate,
+                pathTemplateData
               )
             )
           )
+        )
         : '';
 
       const imageOutputPath = path.resolve(vaultRoot, imageRelativePath);
 
       const imageBaseName = exportFormat.imageBaseNameTemplate
         ? sanitizeFilePath(
-            removeStartingSlash(
-              await renderTemplate(
-                sourcePath,
-                exportFormat.imageBaseNameTemplate,
-                pathTemplateData
-              )
+          removeStartingSlash(
+            await renderTemplate(
+              sourcePath,
+              exportFormat.imageBaseNameTemplate,
+              pathTemplateData
             )
           )
+        )
         : 'image';
+
+      if (item.notes) {
+        const notesMarkdown = await getNotesMarkdownByCiteKey(
+          item.citationKey,
+          item.notes.map(note => note.note),
+          settings,
+          database,
+          imageOutputPath,
+          true
+        )
+        item.notes.map((note, i) => {
+          note.note = notesMarkdown[i];
+        })
+
+      }
 
       const markdownPath = await getMarkdownPath(pathTemplateData);
 

--- a/src/bbt/export.ts
+++ b/src/bbt/export.ts
@@ -724,15 +724,27 @@ export async function exportToMarkdown(
         )
         : 'image';
 
-      if (item.notes) {
+      if (item.notes && !item._notesProcessed) {
+        item._notesProcessed = true;
+        const effectiveSettings = exportFormat.noteImageSettings?.enabled
+          ? {
+            ...settings,
+            noteImageSettings: {
+              ...settings.noteImageSettings,
+              embeddedImageMode: exportFormat.noteImageSettings.embeddedImageMode,
+            },
+          }
+          : settings;
+
         const notesMarkdown = await getNotesMarkdownByCiteKey(
           item.citationKey,
           item.notes.map(note => note.note),
-          settings,
+          effectiveSettings,
           database,
           imageOutputPath,
           true
         )
+
         item.notes.map((note, i) => {
           note.note = notesMarkdown[i];
         })

--- a/src/bbt/exportNotes.ts
+++ b/src/bbt/exportNotes.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync } from 'fs';
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'fs';
 import {
   Editor,
   Notice,
@@ -218,8 +218,13 @@ export async function getNotesMarkdownByCiteKey(
     for (const noteHtml of notes) {
       const imageKeys = extractNoteImageKeys(noteHtml);
       for (const key of imageKeys) {
-        const fullPath = path.join(zoteroStorage, key, 'image.png');
-        attachments.noteImages[key] = fullPath;
+        const keyFolder = path.join(zoteroStorage, key);
+        const imageFile = existsSync(keyFolder)
+          ? readdirSync(keyFolder).find(f => /\.(png|jpg|jpeg|gif|webp)$/.test(f))
+          : undefined;
+        attachments.noteImages[key] = imageFile
+          ? path.join(keyFolder, imageFile)
+          : path.join(keyFolder, 'image.png'); // fallback if folder doesn't exist yet
       }
     }
   }

--- a/src/bbt/exportNotes.ts
+++ b/src/bbt/exportNotes.ts
@@ -131,32 +131,24 @@ export async function processZoteroAnnotationNotes(
   return parsed.body.innerHTML;
 }
 
-export async function noteExportPrompt(
+export async function getNotesMarkdownByCiteKey(
+  citeKey: CiteKey,
+  notes: string[],
+  settings: ZoteroConnectorSettings,
   database: DatabaseWithPort,
-  destination?: string
+  destination?: string,
+  isExportFormat: boolean = false
 ) {
-  const citeKeys = await getCiteKeys(database);
 
-  if (!citeKeys.length) return;
-
-  const notes = await getNotesFromCiteKeys(citeKeys, database);
 
   if (!notes) {
     new Notice('No notes found for selected items', 7000);
     return;
   }
 
-  const keys = Object.keys(notes);
-
-  if (!keys.length) {
-    new Notice('No notes found for selected items', 7000);
-    return;
-  }
-
   const attachments: Record<string, any> = {};
 
-  for (const key of citeKeys) {
-    const attachment = await getAttachmentsFromCiteKey(key, database);
+  const attachment = await getAttachmentsFromCiteKey(citeKey, database);
 
     if (attachment) {
       const images: Record<string, string> = {};
@@ -169,32 +161,71 @@ export async function noteExportPrompt(
         });
       });
 
-      attachments[key.key] = images;
+    attachments[citeKey.key] = images;
+  }
+
+  const zoteroStorage = settings.noteImageSettings.zoteroStoragePath;
+  if (zoteroStorage) {
+    attachments.noteImages = {};
+    for (const noteHtml of notes) {
+      const imageKeys = extractNoteImageKeys(noteHtml);
+      for (const key of imageKeys) {
+        const fullPath = path.join(zoteroStorage, key, 'image.png');
+        attachments.noteImages[key] = fullPath;
+      }
     }
   }
 
-  const notesMarkdown: Record<string, string> = {};
 
-  for (const key of keys) {
+
+
     const processed: string[] = [];
-
-    for (const note of notes[key]) {
+  for (const noteHtml of notes) {
       processed.push(
         htmlToMarkdown(
-          await processZoteroAnnotationNotes(
-            key,
-            note,
-            attachments[key],
-            destination
-          )
+        await processZoteroNotes(
+          noteHtml,
+          attachments,
+          settings,
+          destination,
+          isExportFormat
         )
-      );
-    }
-
-    notesMarkdown[key] = processed.join('\n\n');
+      )
+    );
   }
 
-  return notesMarkdown;
+
+  return processed;
+}
+
+export async function noteExportPrompt(
+  settings: ZoteroConnectorSettings,
+  database: DatabaseWithPort,
+  destination?: string
+) {
+
+  const notesMarkdown: Record<string, string[]> = {};
+  const citeKeys = await getCiteKeys(database);
+
+  if (!citeKeys.length) return;
+
+  const notes = await getNotesFromCiteKeys(citeKeys, database);
+
+  if (!notes) {
+    new Notice('No notes found for selected items', 7000);
+    return;
+  }
+
+  for (const citeKey of citeKeys) {
+    notesMarkdown[citeKey.key] = await getNotesMarkdownByCiteKey(citeKey, notes[citeKey.key], settings, database, destination)
+
+  }
+
+  if (!notesMarkdown) return;
+
+  return Object.fromEntries(
+    Object.entries(notesMarkdown).map(([key, notes]) => [key, notes.join('\n\n')])
+  );
 }
 
 async function getAvailablePathForAttachments(

--- a/src/bbt/exportNotes.ts
+++ b/src/bbt/exportNotes.ts
@@ -10,19 +10,29 @@ import {
 } from 'obsidian';
 import path from 'path';
 import { getVaultRoot } from 'src/helpers';
-import { DatabaseWithPort } from 'src/types';
+import { DatabaseWithPort, ZoteroConnectorSettings } from 'src/types';
 
-import { getCiteKeys } from './cayw';
+import { CiteKey, getCiteKeys } from './cayw';
 import { getLocalURI, mkMDDir, sanitizeFilePath } from './helpers';
 import { getAttachmentsFromCiteKey, getNotesFromCiteKeys } from './jsonRPC';
 import { removeStartingSlash } from './template.helpers';
 
-export async function processZoteroAnnotationNotes(
-  key: string,
+
+export function extractNoteImageKeys(noteHtml: string): string[] {
+  const parsed = new DOMParser().parseFromString(noteHtml, 'text/html');
+  const imgs = parsed.querySelectorAll('img[data-attachment-key]');
+  return Array.from(imgs, (img: any) => img.dataset.attachmentKey).filter(Boolean);
+}
+
+export async function processZoteroNotes(
   noteStr: string,
   attachments: Record<string, any>,
-  destination?: string
+  settings: ZoteroConnectorSettings,
+  destination?: string,
+  isExportFormat: boolean = false
 ) {
+
+
   const parsed = new DOMParser().parseFromString(noteStr, 'text/html');
   const annots = parsed.querySelectorAll('[data-annotation]');
   const cites = parsed.querySelectorAll('[data-citation]');
@@ -128,6 +138,44 @@ export async function processZoteroAnnotationNotes(
     }
   });
 
+  if (settings.noteImageSettings.importEmbeddedImage) {
+    const images = parsed.querySelectorAll('img[data-attachment-key]');
+    for (const img of Array.from(images)) {
+      try {
+        const imgKey = (img as HTMLElement).dataset.attachmentKey;
+        if (!imgKey) continue;
+        const imageSrcPath = attachments.noteImages?.[imgKey];
+
+        if (imageSrcPath && existsSync(imageSrcPath)) {
+          if (settings.noteImageSettings.embeddedImageMode === 'copy') {
+            const parsedPath = path.parse(imageSrcPath);
+            const ext = parsedPath.ext || '.png';
+            const destFileName = `${imgKey}${ext}`
+            const destFolder = isExportFormat ? destination : path.join(getVaultRoot(), destination);
+            const destFullPath = path.join(destFolder, destFileName);
+            const vaultRelativePath = normalizePath(path.join(destination, destFileName));
+
+            if (!existsSync(destFolder)) {
+              mkdirSync(destFolder, { recursive: true });
+            }
+
+            copyFileSync(imageSrcPath, destFullPath);
+            (img as HTMLImageElement).src = vaultRelativePath;
+          }
+          else
+            (img as HTMLImageElement).src = imageSrcPath;
+
+
+          img.removeAttribute('data-attachment-key');
+          img.insertAdjacentElement('afterend', createEl('br'));
+        } else {
+          console.warn(`Could not find note image ${imgKey} at ${imageSrcPath}`);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }
   return parsed.body.innerHTML;
 }
 
@@ -150,16 +198,16 @@ export async function getNotesMarkdownByCiteKey(
 
   const attachment = await getAttachmentsFromCiteKey(citeKey, database);
 
-    if (attachment) {
-      const images: Record<string, string> = {};
+  if (attachment) {
+    const images: Record<string, string> = {};
 
-      attachment.forEach((a: any) => {
-        a.annotations?.forEach((annot: any) => {
-          if (annot.annotationType === 'image') {
-            images[annot.key] = annot.annotationImagePath;
-          }
-        });
+    attachment.forEach((a: any) => {
+      a.annotations?.forEach((annot: any) => {
+        if (annot.annotationType === 'image') {
+          images[annot.key] = annot.annotationImagePath;
+        }
       });
+    });
 
     attachments[citeKey.key] = images;
   }
@@ -179,10 +227,10 @@ export async function getNotesMarkdownByCiteKey(
 
 
 
-    const processed: string[] = [];
+  const processed: string[] = [];
   for (const noteHtml of notes) {
-      processed.push(
-        htmlToMarkdown(
+    processed.push(
+      htmlToMarkdown(
         await processZoteroNotes(
           noteHtml,
           attachments,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import Fuse from 'fuse.js';
 import { EditableFileView, Events, Plugin, TFile } from 'obsidian';
 import { shellPath } from 'shell-path';
-
+import path from 'path';
 import { DataExplorerView, viewType } from './DataExplorerView';
 import { LoadingModal } from './bbt/LoadingModal';
 import { getCAYW } from './bbt/cayw';
@@ -23,6 +23,7 @@ import {
   CiteKeyExport,
   ExportFormat,
   ZoteroConnectorSettings,
+  DEFAULT_ZOTERO_STORAGE_PATH,
 } from './types';
 
 const commandPrefix = 'obsidian-zotero-desktop-connector:';
@@ -30,7 +31,7 @@ const citationCommandIDPrefix = 'zdc-';
 const exportCommandIDPrefix = 'zdc-exp-';
 const DEFAULT_SETTINGS: ZoteroConnectorSettings = {
   database: 'Zotero',
-  noteImportFolder: '',
+  noteImportFolder: '/',
   pdfExportImageDPI: 120,
   pdfExportImageFormat: 'jpg',
   pdfExportImageQuality: 90,
@@ -39,6 +40,11 @@ const DEFAULT_SETTINGS: ZoteroConnectorSettings = {
   citeSuggestTemplate: '[[{{citekey}}]]',
   openNoteAfterImport: false,
   whichNotesToOpenAfterImport: 'first-imported-note',
+  noteImageSettings: {
+    importEmbeddedImage: true,
+    embeddedImageMode: 'copy',
+    zoteroStoragePath: DEFAULT_ZOTERO_STORAGE_PATH,
+  },
 };
 
 async function fixPath() {
@@ -92,6 +98,7 @@ export default class ZoteroConnector extends Plugin {
           port: this.settings.port,
         };
         noteExportPrompt(
+          this.settings,
           database,
           this.app.workspace.getActiveFile()?.parent.path
         ).then((notes) => {
@@ -110,7 +117,7 @@ export default class ZoteroConnector extends Plugin {
           database: this.settings.database,
           port: this.settings.port,
         };
-        noteExportPrompt(database, this.settings.noteImportFolder)
+        noteExportPrompt(this.settings, database, path.join(this.settings.noteImportFolder, 'images'))
           .then((notes) => {
             if (notes) {
               return filesFromNotes(this.settings.noteImportFolder, notes);
@@ -251,7 +258,7 @@ export default class ZoteroConnector extends Plugin {
         case 'last-imported-note': {
           pathOfNotesToOpen.push(
             createdOrUpdatedMarkdownFilesPaths[
-              createdOrUpdatedMarkdownFilesPaths.length - 1
+            createdOrUpdatedMarkdownFilesPaths.length - 1
             ]
           );
           break;

--- a/src/settings/ExportFormatSettings.tsx
+++ b/src/settings/ExportFormatSettings.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { SingleValue } from 'react-select';
 import AsyncSelect from 'react-select/async';
+import { SettingItem
 
-import { ExportFormat } from '../types';
+ } from './SettingItem';
+import { EmbeddedImageMode, ExportFormat, NoteImageSettings } from '../types';
 import { Icon } from './Icon';
 import { cslListRaw } from './cslList';
 import {
@@ -19,6 +21,7 @@ interface FormatSettingsProps {
   index: number;
   removeFormat: (index: number) => void;
   updateFormat: (index: number, format: ExportFormat) => void;
+  globalNoteImageSettings: NoteImageSettings;
 }
 
 export function ExportFormatSettings({
@@ -26,6 +29,7 @@ export function ExportFormatSettings({
   index,
   updateFormat,
   removeFormat,
+  globalNoteImageSettings,
 }: FormatSettingsProps) {
   const loadFileOptions = React.useMemo(() => {
     const fileSearch = buildFileSearch();
@@ -159,7 +163,52 @@ export function ExportFormatSettings({
           attachment.
         </div>
       </div>
-
+     <div className="zt-format__form">
+     <div className="zt-format__label" style={{display:'flex', alignItems:'center', justifyContent:'space-between'}}>Override embedded image mode
+        <span
+          onClick={() => {
+            updateFormat(index, {
+              ...format,
+              noteImageSettings: format.noteImageSettings?.enabled
+                ? undefined
+                : { enabled: true, embeddedImageMode: globalNoteImageSettings.embeddedImageMode },
+            });
+          }}
+          className={`checkbox-container${format.noteImageSettings?.enabled ? ' is-enabled' : ''}`}
+        />
+     </div>
+     <div className="zt-format__input-note" style={{paddingTop: '0px'}}>
+      Note: If <pre>Copy into vault</pre> mode is selected, images will be copied into <pre>Image Output Path</pre> folder. 
+     </div>
+  </div>
+{format.noteImageSettings?.enabled && (
+  <div className="zt-format__form">
+    <div className="zt-format__label">Import mode</div>
+    <div className="zt-format__input-wrapper">
+      <select
+        className="dropdown"
+        value={format.noteImageSettings.embeddedImageMode}
+        onChange={(e) =>
+          updateFormat(index, {
+            ...format,
+            noteImageSettings: {
+              ...format.noteImageSettings,
+              embeddedImageMode: (e.target as HTMLSelectElement).value as EmbeddedImageMode,
+            },
+          })
+        }
+      >
+        <option value="copy">Copy into vault</option>
+        <option value="link">Link from Zotero storage</option>
+      </select>
+    </div>
+    <div className="zt-format__input-note">
+      {format.noteImageSettings.embeddedImageMode === 'copy'
+        ? 'Images will be copied into this format\'s image output path.'
+        : 'Images will be linked directly from Zotero\'s local storage. No files are copied.'}
+    </div>
+  </div>
+)}
       <div className="zt-format__form">
         <div className="zt-format__label">Template File</div>
         <div className="zt-format__input-wrapper">

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -2,6 +2,7 @@ import { App, Notice, PluginSettingTab, debounce } from 'obsidian';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import which from 'which';
+import { DEFAULT_ZOTERO_STORAGE_PATH, NoteImageSettings, EmbeddedImageMode } from '../types';
 
 import ZoteroConnector from '../main';
 import {
@@ -50,6 +51,10 @@ function SettingsComponent({
   const [ocrState, setOCRState] = React.useState(settings.pdfExportImageOCR);
 
   const [concat, setConcat] = React.useState(!!settings.shouldConcat);
+
+  const [noteImageSettings, setNoteImageSettings] = React.useState(
+  settings.noteImageSettings
+);
 
   const updateCite = React.useCallback(
     debounce(
@@ -106,6 +111,15 @@ function SettingsComponent({
     },
     [removeExportFormat]
   );
+
+  const updateNoteImageSetting = React.useCallback(
+  <K extends keyof NoteImageSettings>(key: K, value: NoteImageSettings[K]) => {
+    const updated = { ...noteImageSettings, [key]: value };
+    setNoteImageSettings(updated);
+    updateSetting('noteImageSettings', updated);
+  },
+  [noteImageSettings, updateSetting]
+);
 
   const tessPathRef = React.useRef<HTMLInputElement>(null);
   const tessDataPathRef = React.useRef<HTMLInputElement>(null);
@@ -173,21 +187,69 @@ function SettingsComponent({
         />
       </SettingItem>
       <SettingItem
-        name="Open the created or updated note(s) after import"
-        description="The created or updated markdown files resulting from the import will be automatically opened."
+  name="Import embedded note images"
+  description="When importing Zotero notes, also import images that are embedded directly in notes (e.g. screenshots/external images pasted into a Zotero note), in addition to PDF annotation images."
+>
+  <div
+    onClick={() =>
+      updateNoteImageSetting('importEmbeddedImage', !noteImageSettings.importEmbeddedImage)
+    }
+    className={`checkbox-container${noteImageSettings.importEmbeddedImage ? ' is-enabled' : ''}`}
+  />
+</SettingItem>
+
+{noteImageSettings.importEmbeddedImage && (
+  <div style={{ borderLeft: '2px solid var(--background-modifier-border)', marginLeft: '1em', paddingLeft: '1em' }}>
+    <SettingItem
+      name="Zotero storage location"
+      description={
+        <div>
+          <input
+            onChange={(e) =>
+              updateNoteImageSetting(
+                'zoteroStoragePath',
+                (e.target as HTMLInputElement).value || DEFAULT_ZOTERO_STORAGE_PATH
+              )
+            }
+            type="text"
+            spellCheck={false}
+            placeholder={`Default: ${DEFAULT_ZOTERO_STORAGE_PATH}`}
+            defaultValue={
+              noteImageSettings.zoteroStoragePath !== DEFAULT_ZOTERO_STORAGE_PATH
+                ? noteImageSettings.zoteroStoragePath
+                : ''
+            }
+            style={{ width: '100%', marginTop: '0.5em', marginBottom: '0.3em' }}
+          />
+          <div>Path to your Zotero storage folder, where attached files are kept. Only change this if you have a non-standard Zotero installation.</div>
+        </div>
+      }
+  />
+
+    <SettingItem
+      name="Import mode"
+      description={
+        noteImageSettings.embeddedImageMode === 'copy'
+          ? 'Copy into vault: images are copied into a subfolder (/images) under the chosen location from Note Import Location option. Images are self-contained and accessible without Zotero.'
+          : 'Link from Zotero storage (fragile): images are linked directly from Zotero\'s local storage folder. No files are copied.'
+      }
+    >
+      <select
+        className="dropdown"
+        value={noteImageSettings.embeddedImageMode}
+        onChange={(e) =>
+          updateNoteImageSetting(
+            'embeddedImageMode',
+            (e.target as HTMLSelectElement).value as EmbeddedImageMode
+          )
+        }
       >
-        <div
-          onClick={() => {
-            setOpenNoteAfterImport((state) => {
-              updateSetting('openNoteAfterImport', !state);
-              return !state;
-            });
-          }}
-          className={`checkbox-container${
-            openNoteAfterImportState ? ' is-enabled' : ''
-          }`}
-        />
-      </SettingItem>
+        <option value="copy">Copy into vault</option>
+        <option value="link">Link from Zotero storage</option>
+      </select>
+    </SettingItem>
+  </div>
+)}
       <SettingItem
         name="Which notes to open after import"
         description="Open either the first note imported, the last note imported, or all notes in new tabs."
@@ -254,6 +316,7 @@ function SettingsComponent({
             index={i}
             updateFormat={updateExport}
             removeFormat={removeExport}
+            globalNoteImageSettings={noteImageSettings}
           />
         );
       })}

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,12 @@ export enum SortingOptions {
 
 export type EmbeddedImageMode = 'copy' | 'link';
 
+export interface FormatNoteImageOverride {
+  enabled: boolean;
+  embeddedImageMode: EmbeddedImageMode;
+}
+
+
 export interface ExportFormat {
   name: string;
   outputPathTemplate: string;
@@ -60,6 +66,7 @@ export interface ExportFormat {
 
   templatePath?: string;
   cslStyle?: string;
+  noteImageSettings?: FormatNoteImageOverride;
 
   // Deprecated
   headerTemplatePath?: string;
@@ -71,7 +78,6 @@ export interface ExportToMarkdownParams {
   settings: ZoteroConnectorSettings;
   database: DatabaseWithPort;
   exportFormat: ExportFormat;
-  noteImageSettings: Partial<NoteImageSettings>;
 }
 
 export interface RenderCiteTemplateParams {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,8 @@
+import { homedir } from "os";
+import { join } from "path";
+
+export const DEFAULT_ZOTERO_STORAGE_PATH = join(homedir(), "Zotero/storage/");
+
 export type Format =
   | 'latex'
   | 'biblatex'
@@ -44,6 +49,9 @@ export enum SortingOptions {
   Location = 'location',
 }
 
+
+export type EmbeddedImageMode = 'copy' | 'link';
+
 export interface ExportFormat {
   name: string;
   outputPathTemplate: string;
@@ -63,6 +71,7 @@ export interface ExportToMarkdownParams {
   settings: ZoteroConnectorSettings;
   database: DatabaseWithPort;
   exportFormat: ExportFormat;
+  noteImageSettings: Partial<NoteImageSettings>;
 }
 
 export interface RenderCiteTemplateParams {
@@ -70,6 +79,11 @@ export interface RenderCiteTemplateParams {
   format: CitationFormat;
 }
 
+export interface NoteImageSettings {
+  importEmbeddedImage: boolean;
+  embeddedImageMode: EmbeddedImageMode;
+  zoteroStoragePath: string;
+}
 export interface ZoteroConnectorSettings {
   citeFormats: CitationFormat[];
   citeSuggestTemplate?: string;
@@ -91,6 +105,7 @@ export interface ZoteroConnectorSettings {
   settingsVersion?: number;
   shouldConcat?: boolean;
   whichNotesToOpenAfterImport: NotesToOpenAfterImport;
+  noteImageSettings: NoteImageSettings;
 }
 
 export interface CiteKeyExport {


### PR DESCRIPTION
## Allow embedded images such as external copy-pasted images, screenshots to be imported with notes

With this feature, you can enrich your Zotero notes with image illustrations including: screenshots from the pdf file or copy pasted images from external sources, and import them into Obsidian within the note's body, which was previously limited to annotations (via Select Area tool).

**This PR adds support to importing these images with two modes:**
- **Link mode:** images are linked directly from Zotero's local storage folder and no files are copied which saves disk space. Make sure to correctly configure the Zotero storage path if you have a custom installation.
- **Copy mode:** images are copied from Zotero's local storage folder into _/images_ subfolder of the specified folder in Note Import Location option.

### Settings
A new **"Import embedded note images"** toggle is added to the general settings section, with two sub-options when enabled:
- **Zotero storage location:** path to the Zotero storage folder, defaults to the standard installation path per OS
- **Import mode:** copy or link
<img width="943" height="628" alt="image" src="https://github.com/user-attachments/assets/5ae4d637-df1d-4dce-b128-86a5438dc5c8" />

### Import formats
Each **import format** can additionally override the import mode independently of the global settings and will use **_Image Output Path_** folder as a destination if **Import mode** is set to **_Copy into vault_** option.

<img width="950" height="887" alt="image" src="https://github.com/user-attachments/assets/df5dd6bd-209a-48e3-a1e2-087a5ccd3bcf" />
